### PR TITLE
Fix sftp bug and support get error information

### DIFF
--- a/qtssh/sshclient.h
+++ b/qtssh/sshclient.h
@@ -61,6 +61,7 @@ private:
     quint16 m_port {0};
     int m_errorcode {0};
     bool m_sshConnected {false};
+    int m_connTimeoutCnt;
 
     QString m_hostname;
     QString m_username;
@@ -86,7 +87,7 @@ public:
 
 
 public slots:
-    int connectToHost(const QString & username, const QString & hostname, quint16 port = 22, QByteArrayList methodes = QByteArrayList());
+    int connectToHost(const QString &username, const QString &hostname, quint16 port = 22, QByteArrayList methodes = QByteArrayList(), int connTimeoutMsec = 60000);
     bool waitForState(SshClient::SshState state);
     void disconnectFromHost();
     void resetError();
@@ -136,6 +137,8 @@ public: /* New function implementation with state machine */
     void setName(const QString &name);
 
     void setProxy(QNetworkProxy *proxy);
+
+    void setConnectTimeout(int timeoutMsec);
 
 private: /* New function implementation with state machine */
     SshState m_sshState {SshState::Unconnected};

--- a/qtssh/sshprocess.h
+++ b/qtssh/sshprocess.h
@@ -18,19 +18,18 @@ public:
     virtual ~SshProcess() override;
     void close() override;
     QByteArray result();
+    QStringList errMsg();
     bool isError();
 
 public slots:
     void runCommand(const QString &cmd);
     void sshDataReceived() override;
 
-
-
-
 private:
     QString m_cmd;
     LIBSSH2_CHANNEL *m_sshChannel {nullptr};
     QByteArray m_result;
+    QStringList m_errMsg;
     bool m_error {false};
 
 signals:

--- a/qtssh/sshsftp.h
+++ b/qtssh/sshsftp.h
@@ -21,6 +21,7 @@ private:
     LIBSSH2_SFTP *m_sftpSession {nullptr};
     QString m_mkdir;
     bool m_error {false};
+    QStringList m_errMsg;
 
     QList<SshSftpCommand *> m_cmd;
     SshSftpCommand *m_currentCmd {nullptr};
@@ -48,6 +49,9 @@ public:
 
     LIBSSH2_SFTP *getSftpSession() const;
     bool processCmd(SshSftpCommand *cmd);
+
+    bool isError();
+    QStringList errMsg();
 
 public slots:
     void sshDataReceived() override;

--- a/qtssh/sshsftpcommand.cpp
+++ b/qtssh/sshsftpcommand.cpp
@@ -15,6 +15,11 @@ QString SshSftpCommand::name() const
     return m_name;
 }
 
+QStringList SshSftpCommand::errMsg() const
+{
+    return m_errMsg;
+}
+
 SshSftpCommand::SshSftpCommand(SshSFtp &sftp)
     : QObject(qobject_cast<QObject*>(&sftp))
     , m_sftp(sftp)

--- a/qtssh/sshsftpcommand.h
+++ b/qtssh/sshsftpcommand.h
@@ -37,8 +37,11 @@ public:
 
     QString name() const;
 
+    QStringList errMsg() const;
+
 protected:
     CommandState m_state;
+    QStringList m_errMsg;
 
 signals:
     void stateChanged(CommandState state);

--- a/qtssh/sshsftpcommandfileinfo.cpp
+++ b/qtssh/sshsftpcommandfileinfo.cpp
@@ -41,19 +41,22 @@ void SshSftpCommandFileInfo::process()
                 return;
             }
             m_error = true;
+            m_errMsg << QString("SFTP unlink error: %1").arg(res);
             qCWarning(logsshsftp) << "SFTP unlink error " << res;
             if (res == LIBSSH2_ERROR_SFTP_PROTOCOL)
             {
                 int err = libssh2_sftp_last_error(sftp().getSftpSession());
                 if (err == LIBSSH2_FX_NO_SUCH_FILE)
                 {
-                    qCWarning(logsshsftp) << "No such file or directory:" << m_path;
+                    qCWarning(logsshsftp) << "No such file or directory: " << m_path;
+                    m_errMsg << "No such file or directory: " + m_path;
                     setState(CommandState::Terminate);
                     return;
                 }
                 else
                 {
                     qCWarning(logsshsftp) << "SFTP last error " << err;
+                    m_errMsg << "SFTP last error " + err;
                 }
             }
             setState(CommandState::Error);

--- a/qtssh/sshsftpcommandget.cpp
+++ b/qtssh/sshsftpcommandget.cpp
@@ -32,8 +32,9 @@ void SshSftpCommandGet::process()
             {
                 return;
             }
-            qCDebug(logsshsftp) << "Can't open SFTP file " << m_src << QString(emsg);
+            qCDebug(logsshsftp) << "Can't open SFTP file " << m_src << ", " << QString(emsg);
             m_error = true;
+            m_errMsg << "Can't open SFTP file " + m_src + ", " + QString(emsg);
             setState(CommandState::Error);
             return;
         }
@@ -57,13 +58,14 @@ void SshSftpCommandGet::process()
                 }
                 qCWarning(logsshsftp) << "SFTP read error " << rc;
                 m_error = true;
-                setState(Error);
+                m_errMsg << QString("SFTP read error: %1").arg(rc);
+                setState(CommandState::Error);
                 break;
             }
             else if(rc == 0)
             {
                 // EOF
-                setState(Closing);
+                setState(CommandState::Closing);
                 break;
             }
             else
@@ -92,6 +94,7 @@ void SshSftpCommandGet::process()
                 return;
             }
             qCWarning(logsshsftp) << "SFTP close error " << rc;
+            m_errMsg << QString("SFTP close error: %1").arg(rc);
             setState(CommandState::Error);
         }
         if(m_error)

--- a/qtssh/sshsftpcommandget.h
+++ b/qtssh/sshsftpcommandget.h
@@ -12,7 +12,7 @@ class SshSftpCommandGet : public SshSftpCommand
     QFile &m_fout;
     const QString &m_src;
     LIBSSH2_SFTP_HANDLE *m_sftpfile;
-    bool m_error;
+    bool m_error {false};
     char m_buffer[SFTP_BUFFER_SIZE];
 
 public:

--- a/qtssh/sshsftpcommandmkdir.cpp
+++ b/qtssh/sshsftpcommandmkdir.cpp
@@ -35,6 +35,7 @@ void SshSftpCommandMkdir::process()
                 return;
             }
             m_error = true;
+            m_errMsg << "SFTP mkdir error " + res;
             qCWarning(logsshsftp) << "SFTP mkdir error " << res;
             setState(CommandState::Error);
             break;

--- a/qtssh/sshsftpcommandreaddir.cpp
+++ b/qtssh/sshsftpcommandreaddir.cpp
@@ -36,8 +36,9 @@ void SshSftpCommandReadDir::process()
             {
                 return;
             }
-            qCDebug(logsshsftp) << "Can't open SFTP dir " << m_dir << QString(emsg);
+            qCDebug(logsshsftp) << "Can't open SFTP dir " << m_dir << ", " << QString(emsg);
             m_error = true;
+            m_errMsg << "Can't open SFTP dir " + m_dir + ", " + QString(emsg);
             setState(CommandState::Error);
             return;
         }
@@ -57,6 +58,7 @@ void SshSftpCommandReadDir::process()
                     return;
                 }
                 qCWarning(logsshsftp) << "SFTP readdir error " << rc;
+                m_errMsg << QString("SFTP readdir error: %1").arg(rc);
             }
             else if(rc == 0)
             {
@@ -79,7 +81,8 @@ void SshSftpCommandReadDir::process()
             {
                 return;
             }
-            qCWarning(logsshsftp) << "SFTP Write error " << rc;
+            qCWarning(logsshsftp) << "SFTP close error " << rc;
+            m_errMsg << QString("SFTP close error: %1").arg(rc);
             setState(CommandState::Error);
         }
         if(m_error)

--- a/qtssh/sshsftpcommandsend.cpp
+++ b/qtssh/sshsftpcommandsend.cpp
@@ -6,7 +6,7 @@ SshSftpCommandSend::SshSftpCommandSend(const QString &source, QString dest, SshS
     , m_dest(dest)
     , m_localfile(source)
 {
-    setName(QString("send(%1, %2)").arg(source).arg(dest));
+    setName(QString("send(%1, %2)").arg(source, dest));
 }
 
 void SshSftpCommandSend::process()
@@ -32,8 +32,9 @@ void SshSftpCommandSend::process()
             {
                 return;
             }
-            qCDebug(logsshsftp) << "Can't open SFTP file " << m_localfile.fileName() << QString(emsg);
+            qCDebug(logsshsftp) << "Can't open SFTP file " << m_dest << ", " << QString(emsg);
             m_error = true;
+            m_errMsg << "Can't open SFTP file " + m_dest + ", " + QString(emsg);
             setState(CommandState::Error);
             return;
         }
@@ -42,6 +43,7 @@ void SshSftpCommandSend::process()
         {
             qCWarning(logsshsftp) << "Can't open local file " << m_localfile.fileName();
             m_error = true;
+            m_errMsg << "Can't open local file " + m_localfile.fileName();
             setState(CommandState::Closing);
             break;
         }
@@ -90,7 +92,8 @@ void SshSftpCommandSend::process()
             {
                 return;
             }
-            qCWarning(logsshsftp) << "SFTP Write error " << rc;
+            qCWarning(logsshsftp) << "SFTP close error " << rc;
+            m_errMsg << QString("SFTP close error: %1").arg(rc);
             setState(CommandState::Error);
         }
         if(m_error)

--- a/qtssh/sshsftpcommandsend.h
+++ b/qtssh/sshsftpcommandsend.h
@@ -15,7 +15,7 @@ class SshSftpCommandSend: public SshSftpCommand
     Q_OBJECT
 
     QString m_dest;
-    bool m_error;
+    bool m_error {false};
 
     QFile m_localfile;
     char m_buffer[SFTP_BUFFER_SIZE];

--- a/qtssh/sshsftpcommandunlink.cpp
+++ b/qtssh/sshsftpcommandunlink.cpp
@@ -32,6 +32,7 @@ void SshSftpCommandUnlink::process()
                 return;
             }
             m_error = true;
+            m_errMsg << QString("SFTP unlink error: %1").arg(res);
             qCWarning(logsshsftp) << "SFTP unlink error " << res;
             setState(CommandState::Error);
             break;


### PR DESCRIPTION
1. fix sftp reporting errors due to uninitialized variables；
2. add interface support to get error information;
3. default use NoProxy if not specified proxy type;
4. support set connect timeout;
